### PR TITLE
add __name__ == "__main__" idiom

### DIFF
--- a/maincode.py
+++ b/maincode.py
@@ -201,4 +201,5 @@ def extract():
     except Exception as e:
         print(e)
 
-extract()
+if __name__ == "__main__":
+    extract()


### PR DESCRIPTION
This allows for your maincode.py code only to be executed when run as script, but not when imported (like you do in help.py).